### PR TITLE
Add control glyphs for tooltips

### DIFF
--- a/default/assets/crosscraft/textures/interface/controller_glyphs/generic.png
+++ b/default/assets/crosscraft/textures/interface/controller_glyphs/generic.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0aefcf4ba1b4e243bd817e62eec4bb20c32e4e8eb37fb8f406f7c9c073994d1
+size 2759

--- a/default/assets/crosscraft/textures/interface/controller_glyphs/kbm.png
+++ b/default/assets/crosscraft/textures/interface/controller_glyphs/kbm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10a309f6df75b8eca562f749cb0b7873a083046d587fc520073b9774f9f3fff1
+size 1060

--- a/default/assets/crosscraft/textures/interface/controller_glyphs/nintendo.png
+++ b/default/assets/crosscraft/textures/interface/controller_glyphs/nintendo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed1b9a8e930161cb025e1a70d3f2b42bd9fc56bd63a030a983a7ca97309ea1f
+size 2390

--- a/default/assets/crosscraft/textures/interface/controller_glyphs/psp.png
+++ b/default/assets/crosscraft/textures/interface/controller_glyphs/psp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc9df4d8ad5a7b607244c95d6cf681207bc313ec4c30e587f0e17df4a4dc340c
+size 885

--- a/default/assets/crosscraft/textures/interface/controller_glyphs/sony.png
+++ b/default/assets/crosscraft/textures/interface/controller_glyphs/sony.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d12e966f840ef23b801f4769fb3d4df96fb4ecea79be5d6002b4301de1c439c8
+size 3790

--- a/default/assets/crosscraft/textures/interface/controller_glyphs/xbox.png
+++ b/default/assets/crosscraft/textures/interface/controller_glyphs/xbox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d1a7ee37704a43945659ae7b4a57f04c9628d08c77e22432b4d45a555969419
+size 3400


### PR DESCRIPTION
What it says on the tin, for LCE-adjacent control tooltips this PR checks in glyphs for the following

- Generic Controller
- Nintendo Branded
- Sony Branded
- Xbox Branded
- Keyboard/Mouse
- Platform Specific: PSP